### PR TITLE
Overhaul documentation processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 Gemfile.lock
 
 # Dockmaster files
-docs/
+/docs/
 
 # Misc. files
 coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Metrics/BlockLength:
     - 'spec/dockmaster/parser/store_spec.rb'
     - 'spec/dockmaster/plugin_spec.rb'
 Metrics/ClassLength:
-  Max: 150
+  Max: 200
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ Metrics/AbcSize:
   Max: 25
 Metrics/BlockLength:
   Exclude:
+    - 'spec/dockmaster/docs/processor_defaults_spec.rb'
     - 'spec/dockmaster/output/erb/base_helper_spec.rb'
     - 'spec/dockmaster/parser/doc_parser_spec.rb'
     - 'spec/dockmaster/parser/store_spec.rb'
@@ -15,7 +16,7 @@ Metrics/LineLength:
   Max: 120
 Metrics/MethodLength:
   CountComments: false
-  Max: 20
+  Max: 30
 Metrics/PerceivedComplexity:
   Max: 10
 EndOfLine:

--- a/lib/dockmaster.rb
+++ b/lib/dockmaster.rb
@@ -31,11 +31,15 @@ require 'dockmaster/cli/command'
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+#
+# @author Christopher Lutz
 module Dockmaster
   autoload :CLI, 'dockmaster/cli/cli'
   autoload :Configuration, 'dockmaster/configuration'
   autoload :Data, 'dockmaster/parser/data'
   autoload :DocParser, 'dockmaster/parser/doc_parser'
+  autoload :DocProcessor, 'dockmaster/docs/doc_processor'
+  autoload :Docs, 'dockmaster/docs/docs'
   autoload :External, 'dockmaster/external'
   autoload :Output, 'dockmaster/output/output'
   autoload :Plugin, 'dockmaster/plugin'

--- a/lib/dockmaster/docs/doc_processor.rb
+++ b/lib/dockmaster/docs/doc_processor.rb
@@ -1,0 +1,73 @@
+module Dockmaster
+  # This class processes documentation comments into usable formats
+  class DocProcessor
+    class << self
+      def process(doc_comment, file)
+        @file = file
+
+        @text = ''
+        @params = {}
+        @return = ''
+        @author = ''
+
+        process_lines(doc_comment)
+
+        @text = process_internal(@text)
+
+        Dockmaster::Docs.new(@text.strip, @params, @return, @author)
+      end
+
+      private
+
+      def process_lines(doc_comment)
+        doc_comment.split("\n").each do |line|
+          # Strip '#' and any outside whitespace
+          text = line[1..-1].strip
+
+          if text.empty?
+            @text += "\n\n"
+          elsif text.start_with?('@')
+            @text.strip!
+            process_annotation(text)
+          else
+            @text += "#{text} "
+          end
+        end
+      rescue
+        abort "ERROR: Malformed documentation in '#{@file}'"
+      end
+
+      def process_annotation(text)
+        annotation = text.split(' ')[0]
+
+        case annotation
+        when '@param'
+          parse_param(text[annotation.length..-1].strip)
+        when '@return'
+          @return = process_internal(text[annotation.length..-1].strip)
+        when '@author'
+          @author = process_internal(text[annotation.length..-1].strip)
+        end
+      rescue
+        abort "ERROR: Malformed @ doc annotation in '#{@file}'"
+      end
+
+      def parse_param(text)
+        param = text.split(' ')[0]
+        desc = text[param.length..-1].strip
+
+        @params[param] = process_internal(desc)
+      rescue
+        abort "ERROR: Malformed @param doc annotation in '#{@file}'"
+      end
+
+      def process_internal(text)
+        text.strip!
+        text.gsub!("\n", '<br>')
+        text
+      rescue
+        abort "ERROR: Malformed documentation in '#{@file}'"
+      end
+    end
+  end
+end

--- a/lib/dockmaster/docs/doc_processor.rb
+++ b/lib/dockmaster/docs/doc_processor.rb
@@ -1,3 +1,5 @@
+require 'dockmaster/docs/processor_defaults'
+
 module Dockmaster
   # This class processes documentation comments into usable formats
   class DocProcessor
@@ -6,15 +8,54 @@ module Dockmaster
         @file = file
 
         @text = ''
-        @params = {}
-        @return = ''
-        @author = ''
+
+        @fields = {}
+
+        ProcessorDefaults.register_internals
 
         process_lines(doc_comment)
 
-        @text = process_internal(@text)
+        @text = process_internal_documentation(@text)
+        @text.strip!
+        @text.gsub!("\n", '<br>')
 
-        Dockmaster::Docs.new(@text.strip, @params, @return, @author)
+        Dockmaster::Docs.new(@text.strip, @fields)
+      end
+
+      def handlers
+        @handlers ||= {}
+      end
+
+      def internal_handlers
+        @internal_handlers ||= {}
+      end
+
+      def see_links
+        @see_links ||= {}
+      end
+
+      def register_internal_annotation_handler(annotation, &block)
+        internal_handlers[annotation] = block
+      end
+
+      def register_annotation_handler(annotation, &block)
+        handlers[annotation] = block
+      end
+
+      def process_internal_documentation(text)
+        process_internal(text)
+      end
+
+      def retrieve(name)
+        @fields[name]
+      end
+
+      def retrieve_with_default(name, default)
+        @fields[name] ||= default
+      end
+
+      def set(name, value)
+        @fields[name] = value
       end
 
       private
@@ -38,35 +79,57 @@ module Dockmaster
       end
 
       def process_annotation(text)
-        annotation = text.split(' ')[0]
-
-        case annotation
-        when '@param'
-          parse_param(text[annotation.length..-1].strip)
-        when '@return'
-          @return = process_internal(text[annotation.length..-1].strip)
-        when '@author'
-          @author = process_internal(text[annotation.length..-1].strip)
-        end
+        annot = text.split(' ')[0][1..-1].to_sym
+        return unless handlers.key?(annot)
+        handler = handlers[annot]
+        return if handler.nil?
+        intern = text[1 + annot.length..-1].strip
+        handler.call(intern)
       rescue
-        abort "ERROR: Malformed @ doc annotation in '#{@file}'"
-      end
-
-      def parse_param(text)
-        param = text.split(' ')[0]
-        desc = text[param.length..-1].strip
-
-        @params[param] = process_internal(desc)
-      rescue
-        abort "ERROR: Malformed @param doc annotation in '#{@file}'"
+        abort "ERROR: Malformed doc annotation in '#{@file}'"
       end
 
       def process_internal(text)
-        text.strip!
-        text.gsub!("\n", '<br>')
-        text
+        level = 0
+        intern = ''
+        final = ''
+
+        text.each_char do |char|
+          if char == '{'
+            level += 1
+          elsif char == '}'
+            if level > 1
+              level -= 1
+            elsif level == 1
+              result = process_internal_annotation(intern)
+              final += result
+              intern = ''
+              level = 0
+            end
+          elsif level > 0
+            intern += char
+          else
+            final += char
+          end
+        end
+
+        final
       rescue
         abort "ERROR: Malformed documentation in '#{@file}'"
+      end
+
+      def process_internal_annotation(text)
+        text.strip!
+        return text unless text.start_with?('@')
+        annot = text.split(' ')[0][1..-1].to_sym
+        return text unless internal_handlers.key?(annot)
+        handler = internal_handlers[annot]
+        return text if handler.nil?
+        intern = text[1 + annot.length..-1].strip
+        result = handler.call(intern)
+        result
+      rescue
+        abort "ERROR: Malformed internal doc annotation in '#{@file}'"
       end
     end
   end

--- a/lib/dockmaster/docs/docs.rb
+++ b/lib/dockmaster/docs/docs.rb
@@ -1,0 +1,13 @@
+module Dockmaster
+  # This class represents processed documentation
+  class Docs
+    attr_reader :desc, :params, :return, :author
+
+    def initialize(desc, params, ret, author)
+      @desc = desc
+      @params = params
+      @return = ret
+      @author = author
+    end
+  end
+end

--- a/lib/dockmaster/docs/docs.rb
+++ b/lib/dockmaster/docs/docs.rb
@@ -1,13 +1,15 @@
 module Dockmaster
   # This class represents processed documentation
   class Docs
-    attr_reader :desc, :params, :return, :author
+    attr_reader :description, :fields
 
-    def initialize(desc, params, ret, author)
-      @desc = desc
-      @params = params
-      @return = ret
-      @author = author
+    def initialize(desc, fields)
+      @description = desc
+      @fields = fields
+    end
+
+    def [](field)
+      @fields[field]
     end
   end
 end

--- a/lib/dockmaster/docs/processor_defaults.rb
+++ b/lib/dockmaster/docs/processor_defaults.rb
@@ -1,0 +1,71 @@
+require 'dockmaster/docs/doc_processor'
+
+module Dockmaster
+  # This class handles default handlers, etc. for the documentation processor
+  class ProcessorDefaults
+    class << self
+      def register_internals
+        register_basic_handlers
+
+        register_code_handlers
+        register_link_handlers
+      end
+
+      private
+
+      def register_code_handlers
+        # code annotation
+        DocProcessor.register_internal_annotation_handler(:code) do |text|
+          "<code>#{DocProcessor.process_internal_documentation(text)}</code>"
+        end
+      end
+
+      def register_link_handlers
+        # link annotation
+        DocProcessor.register_internal_annotation_handler(:link) do |text|
+          link = text.split(' ')[0]
+          text = text[link.length..-1].strip
+          text = link if text.empty?
+          "<a href=\"#{link}\">#{DocProcessor.process_internal_documentation(text)}</a>"
+        end
+
+        # see annotation
+        DocProcessor.register_internal_annotation_handler(:see) do |text|
+          see_link = DocProcessor.see_links[text]
+          link = ''
+          if see_link.nil?
+            puts "Unrecognized reference to #{text} found in '#{@file}'"
+            link = '#'
+          else
+            link = see_link
+          end
+
+          "<em>(see <a href=\"#{link}\">#{text}</a>)</em>"
+        end
+      end
+
+      def register_basic_handlers
+        # param annotation
+        DocProcessor.register_annotation_handler(:param) do |text|
+          param = text.split(' ')[0]
+          desc = text[param.length..-1].strip
+          desc = DocProcessor.process_internal_documentation(desc)
+
+          DocProcessor.retrieve_with_default(:params, {})[param] = desc
+        end
+
+        # return annotation
+        DocProcessor.register_annotation_handler(:return) do |text|
+          processed = DocProcessor.process_internal_documentation(text)
+          DocProcessor.set(:return, processed)
+        end
+
+        # author annotation
+        DocProcessor.register_annotation_handler(:author) do |text|
+          processed = DocProcessor.process_internal_documentation(text)
+          DocProcessor.set(:author, processed)
+        end
+      end
+    end
+  end
+end

--- a/lib/dockmaster/external.rb
+++ b/lib/dockmaster/external.rb
@@ -44,6 +44,14 @@ Cannot find plugin '#{plugin}'.  It may be contained in a gem such as 'dockmaste
         end
       end
 
+      def silent_output
+        old_stdout = $stdout
+        $stdout = StringIO.new
+        yield
+      ensure
+        $stdout = old_stdout
+      end
+
       private
 
       def silent_warnings

--- a/lib/dockmaster/parser/data.rb
+++ b/lib/dockmaster/parser/data.rb
@@ -2,13 +2,14 @@ module Dockmaster
   # Represents data for a
   # method or field in a Store
   class Data
-    attr_reader :docs
+    attr_accessor :docs
+    attr_reader :doc_str
     attr_reader :file
     attr_reader :ast
     attr_reader :line
 
-    def initialize(docs, file, ast, line)
-      @docs = docs
+    def initialize(doc_str, file, ast, line)
+      @doc_str = doc_str
       @file = file
       @ast = ast
       @line = line

--- a/lib/dockmaster/parser/doc_parser.rb
+++ b/lib/dockmaster/parser/doc_parser.rb
@@ -15,6 +15,9 @@ module Dockmaster
           store = parse_file(file, store, false)
         end
 
+        store.parse_see_links
+        store.parse_docs
+
         store
       end
 
@@ -126,7 +129,7 @@ module Dockmaster
 
           sub_store = Dockmaster::Store.from_cache(store, type, child.to_a[1])
           doc_str = closest_comment(line, comments)
-          sub_store.docs = Dockmaster::DocProcessor.process(doc_str.strip, @file)
+          sub_store.doc_str = doc_str
 
           yield if block_given?
 
@@ -162,8 +165,7 @@ module Dockmaster
         end
 
         doc_str = closest_comment(line, comments)
-        docs = Dockmaster::DocProcessor.process(doc_str.strip, @file)
-        store.method_data.store(name, Dockmaster::Data.new(docs, @file, ast, line))
+        store.method_data.store(name, Dockmaster::Data.new(doc_str, @file, ast, line))
 
         store
       end
@@ -173,10 +175,9 @@ module Dockmaster
         name = ast_ary[1]
 
         doc_str = closest_comment(line, comments)
-        docs = Dockmaster::DocProcessor.process(doc_str.strip, @file)
 
         # TODO: differentiate between constants and others
-        store.field_data.store(name, Dockmaster::Data.new(docs, @file, ast, line))
+        store.field_data.store(name, Dockmaster::Data.new(doc_str, @file, ast, line))
 
         store
       end

--- a/lib/dockmaster/parser/doc_parser.rb
+++ b/lib/dockmaster/parser/doc_parser.rb
@@ -125,7 +125,8 @@ module Dockmaster
           in_cache = Dockmaster::Store.in_cache?(store, type, child.to_a[1])
 
           sub_store = Dockmaster::Store.from_cache(store, type, child.to_a[1])
-          sub_store.docs = closest_comment(line, comments)
+          doc_str = closest_comment(line, comments)
+          sub_store.docs = Dockmaster::DocProcessor.process(doc_str.strip, @file)
 
           yield if block_given?
 
@@ -160,8 +161,8 @@ module Dockmaster
           end
         end
 
-        docs = closest_comment(line, comments)
-
+        doc_str = closest_comment(line, comments)
+        docs = Dockmaster::DocProcessor.process(doc_str.strip, @file)
         store.method_data.store(name, Dockmaster::Data.new(docs, @file, ast, line))
 
         store
@@ -171,7 +172,8 @@ module Dockmaster
         ast_ary = ast.to_a
         name = ast_ary[1]
 
-        docs = closest_comment(line, comments)
+        doc_str = closest_comment(line, comments)
+        docs = Dockmaster::DocProcessor.process(doc_str.strip, @file)
 
         # TODO: differentiate between constants and others
         store.field_data.store(name, Dockmaster::Data.new(docs, @file, ast, line))

--- a/spec/dockmaster/docs/processor_defaults_spec.rb
+++ b/spec/dockmaster/docs/processor_defaults_spec.rb
@@ -1,0 +1,71 @@
+require 'dockmaster/docs/processor_defaults'
+
+RSpec.describe Dockmaster::ProcessorDefaults do
+  context 'with @code annotation' do
+    it 'formats the text inside of a <code> tag' do
+      src = '{@code test}'
+      result = Dockmaster::DocProcessor.process_internal_documentation(src)
+
+      expect(result).to eq('<code>test</code>')
+    end
+  end
+
+  context 'with @link annotation' do
+    it 'formats the text inside of an <a> tag' do
+      src = '{@link example.com text}'
+      result = Dockmaster::DocProcessor.process_internal_documentation(src)
+
+      expect(result).to eq('<a href="example.com">text</a>')
+    end
+  end
+
+  context 'with @see annotation' do
+    it 'formats the text inside of an <a> tag and retrieves the correct URL' do
+      src = '{@see Test::test}'
+      Dockmaster::DocProcessor.see_links['Test::test'] = 'test'
+      result = Dockmaster::DocProcessor.process_internal_documentation(src)
+
+      expect(result).to eq('<em>(see <a href="test">Test::test</a>)</em>')
+    end
+
+    context 'with an incorrect reference' do
+      it 'returns # for the link' do
+        src = '{@see TestFail::test}'
+
+        result = nil
+        Dockmaster::External.silent_output do
+          result = Dockmaster::DocProcessor.process_internal_documentation(src)
+        end
+
+        expect(result).to eq('<em>(see <a href="#">TestFail::test</a>)</em>')
+      end
+    end
+  end
+
+  context 'with @param annotation' do
+    it 'processes the param name and description' do
+      src = '# @param test desc'
+      result = Dockmaster::DocProcessor.process(src, '<none>')
+
+      expect(result[:params]).to eq('test' => 'desc')
+    end
+  end
+
+  context 'with @author annotation' do
+    it 'saves the author\'s name' do
+      src = '# @author test'
+      result = Dockmaster::DocProcessor.process(src, '<none>')
+
+      expect(result[:author]).to eq('test')
+    end
+  end
+
+  context 'with @return annotation' do
+    it 'saves the return value\'s description' do
+      src = '# @return test'
+      result = Dockmaster::DocProcessor.process(src, '<none>')
+
+      expect(result[:return]).to eq('test')
+    end
+  end
+end

--- a/spec/dockmaster/output/output_spec.rb
+++ b/spec/dockmaster/output/output_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe Dockmaster::Output do
       it 'creates an \'index.html\' and module files' do
         store = Dockmaster::DocParser.parse_string('module Test; end', Dockmaster::Store.new(nil, :none, ''))
 
+        store.parse_see_links
+        store.parse_docs
+
         Dockmaster::Output.start_processing(store)
 
         entries = Dir["#{Dockmaster::CONFIG[:output]}/*.html"]

--- a/spec/dockmaster/parser/store_spec.rb
+++ b/spec/dockmaster/parser/store_spec.rb
@@ -25,31 +25,41 @@ RSpec.describe Dockmaster::Store do
   end
 
   describe '#inspect' do
-    it 'returns a formatted string' do
-      source_str = <<-END
-# Test documentation
-module TestModule
-  # Test documentation
-  TEST_FIELD = 0
+    it 'returns a correctly formatted string' do
+      src = <<-END
+# Documentation
+module Test
+  TEST = 'test'.freeze
 
-  # Test documentation
-  def test_method
+  # A field with docs
+  TEST_W_DOCS = 'test'.freeze
+
+  # More documentation
+  class TestClass
+    def method
+    end
+
+    # Method with docs
+    def method_w_docs
+    end
   end
 end
       END
+
       store = Dockmaster::Store.new(nil, :none, '')
-      store = Dockmaster::DocParser.parse_string(source_str, store)
+      store = Dockmaster::DocParser.parse_string(src, store)
 
-      str = store.inspect
-
-      expected = <<-END
-(none, )
-  (module, TestModule, "# Test documentation")
-    (field, TEST_FIELD, "# Test documentation")
-    (method, test_method, "# Test documentation")
+      exp = <<-END
+(none, , has docs? false)
+  (module, Test, has docs? true)
+    (field, TEST, has docs? false)
+    (field, TEST_W_DOCS, has docs? true)
+    (class, TestClass, has docs? true)
+      (method, method, has docs? false)
+      (method, method_w_docs, has docs? true)
       END
 
-      expect(str).to eq(expected)
+      expect(store.inspect).to eq(exp)
     end
   end
 end

--- a/spec/files/parser_test/testfile_1.rb
+++ b/spec/files/parser_test/testfile_1.rb
@@ -1,10 +1,15 @@
 module TestFiles
   # Test documentation for TestFile1
+  #
+  # @author test(1)
   class TestFile1
     # A field (1)
     TEST1 = 'test'.freeze
 
     # A method (1)
+    #
+    # @param test desc(1)
+    # @return test(1)
     def test_method_1(test); end
   end
 end

--- a/spec/files/parser_test/testfile_2.rb
+++ b/spec/files/parser_test/testfile_2.rb
@@ -1,10 +1,15 @@
 module TestFiles
   # Test documentation for TestFile2
+  #
+  # @author test(2)
   class TestFile2
     # A field (2)
     TEST2 = 'test'.freeze
 
     # A method (2)
+    #
+    # @param test desc(2)
+    # @return test(2)
     def test_method_2(test); end
   end
 end

--- a/spec/files/testfile_doc_parser.rb
+++ b/spec/files/testfile_doc_parser.rb
@@ -1,3 +1,5 @@
 # Documentation
+#
+# @author test
 module TestModule
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 SimpleCov.start
 
 require 'dockmaster'
+require 'dockmaster/docs/processor_defaults'
 
 RSpec.configure do |config|
   config.order = :random
@@ -23,6 +24,8 @@ RSpec.configure do |config|
     Dockmaster::CONFIG[:output] = 'rspec/tests/files'
 
     Dockmaster.load_externals
+
+    Dockmaster::ProcessorDefaults.register_internals
   end
 
   config.after(:each) do


### PR DESCRIPTION
This PR adds in functionality for processing documentation through annotations such as `@param`, `@return`, etc.  `Store#docs` returns a `Docs` instance now, rather than plain text.