### PR TITLE
Overhaul parser

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - 'spec/dockmaster/docs/processor_defaults_spec.rb'
+    - 'spec/dockmaster/output/output_spec.rb'
     - 'spec/dockmaster/output/erb/base_helper_spec.rb'
     - 'spec/dockmaster/parser/doc_parser_spec.rb'
     - 'spec/dockmaster/parser/store_spec.rb'
@@ -11,13 +12,15 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 200
 Metrics/CyclomaticComplexity:
-  Max: 10
+  Enabled: false
 Metrics/LineLength:
   Max: 120
 Metrics/MethodLength:
   CountComments: false
   Max: 30
+Metrics/ParameterLists:
+  Enabled: false
 Metrics/PerceivedComplexity:
-  Max: 10
+  Enabled: false
 EndOfLine:
   Enabled: false

--- a/lib/dockmaster.rb
+++ b/lib/dockmaster.rb
@@ -74,6 +74,14 @@ module Dockmaster
     @no_build ||= false
   end
 
+  def include_private
+    @inc_priv = true
+  end
+
+  def include_private?
+    @inc_priv ||= false
+  end
+
   def load_externals
     Dockmaster::External.load_theme
     Dockmaster::External.load_plugins

--- a/lib/dockmaster/cli/options.rb
+++ b/lib/dockmaster/cli/options.rb
@@ -11,6 +11,7 @@ module Dockmaster
         Dockmaster.debug if options.key?(:debug) || short_options.key?(:d)
         Dockmaster.serve_at_end if options[:serve] || short_options.key?(:s)
         Dockmaster.no_build if options['no-build'.to_sym] || short_options.key?(:n)
+        Dockmaster.include_private if options['include-private'.to_sym] || short_options.key?(:p)
         puts "Dockmaster v#{Dockmaster::VERSION}" if options[:version] || short_options.key?(:v)
 
         return unless options[:help]

--- a/lib/dockmaster/docs/processor_defaults.rb
+++ b/lib/dockmaster/docs/processor_defaults.rb
@@ -70,6 +70,12 @@ module Dockmaster
           processed = DocProcessor.process_internal_documentation(text)
           DocProcessor.set(:author, processed)
         end
+
+        # api annotation
+        DocProcessor.register_annotation_handler(:api) do |text|
+          sym = text.to_sym
+          DocProcessor.set(:api, sym)
+        end
       end
     end
   end

--- a/lib/dockmaster/output/erb/base_helper.rb
+++ b/lib/dockmaster/output/erb/base_helper.rb
@@ -9,28 +9,14 @@ module Dockmaster
       @store = store
     end
 
-    def method_names
-      Array.new(@store.method_data.keys).sort
+    def names(type)
+      Array.new(@store.data_type(type).keys).sort
     end
 
-    def field_names
-      Array.new(@store.field_data.keys).sort
-    end
-
-    def method_source(name)
-      if @store.method_data.key?(name)
-        data = @store.method_data[name]
-        return data_source(data)
-      end
-      ''
-    end
-
-    def field_source(name)
-      if @store.field_data.key?(name)
-        data = @store.field_data[name]
-        return data_source(data)
-      end
-      ''
+    def source(type, name)
+      data = @store.data_type(type)[name]
+      return '' if data.nil?
+      data_source(data)
     end
 
     def data_source(data)

--- a/lib/dockmaster/parser/ast_parsers/class_module_parser.rb
+++ b/lib/dockmaster/parser/ast_parsers/class_module_parser.rb
@@ -1,0 +1,22 @@
+require 'dockmaster/parser/doc_parser'
+
+module Dockmaster
+  # This parser class parses class and module declarations
+  class ClassModuleParser
+    class << self
+      def parse(line, ast, comments, store, _static, _priv)
+        return nil unless ast.type == :module || ast.type == :class
+        type = ast.type
+        return store if (child = DocParser.valid_first_child(ast, :const)).nil?
+        in_cache = Dockmaster::Store.in_cache?(store, type, child.to_a[1])
+
+        sub_store = Dockmaster::Store.from_cache(store, type, child.to_a[1])
+        sub_store.doc_str = DocParser.closest_comment(line, comments)
+        sub_store = DocParser.traverse_ast(ast, comments, sub_store, false, false)
+
+        store.children << sub_store unless in_cache
+        store
+      end
+    end
+  end
+end

--- a/lib/dockmaster/parser/ast_parsers/constant_parser.rb
+++ b/lib/dockmaster/parser/ast_parsers/constant_parser.rb
@@ -1,0 +1,22 @@
+require 'dockmaster/parser/doc_parser'
+
+module Dockmaster
+  # This parser class parses constant value declarations
+  class ConstantParser
+    class << self
+      def parse(line, ast, comments, store, _static, priv)
+        return nil unless ast.type == :casgn
+        return store if priv && !Dockmaster.include_private?
+        ast_ary = ast.to_a
+        name = ast_ary[1]
+
+        doc_str = DocParser.closest_comment(line, comments)
+
+        data = Dockmaster::Data.new(doc_str, DocParser.file, ast, line, priv)
+        store.data_type(:constant).store(name, data)
+
+        store
+      end
+    end
+  end
+end

--- a/lib/dockmaster/parser/ast_parsers/field_parser.rb
+++ b/lib/dockmaster/parser/ast_parsers/field_parser.rb
@@ -1,0 +1,40 @@
+require 'dockmaster/parser/doc_parser'
+
+module Dockmaster
+  # This parser class parses field declarations
+  class FieldParser
+    class << self
+      def parse(line, ast, comments, store, static, priv)
+        valid = false
+        ary = Array.new(ast.to_a)
+        if ary.length >= 1
+          ary.shift
+          valid = ary[0] == :attr_reader
+          valid = ary[0] == :attr_writer unless valid
+          valid = ary[0] == :attr_accessor unless valid
+        end
+        return nil unless ast.type == :send && valid
+        return store if priv && !Dockmaster.include_private?
+
+        define = ary.shift
+
+        doc_str = DocParser.closest_comment(line, comments)
+
+        data_store = if static
+                       store.data_type(:static_field)
+                     else
+                       store.data_type(:instance_field)
+                     end
+
+        ary.each do |child|
+          next unless child.type == :sym
+          data = Dockmaster::Data.new(doc_str, DocParser.file, ast, line, priv)
+          data.readonly = true if define == :attr_reader
+          data_store.store(child.to_a[0], data)
+        end
+
+        store
+      end
+    end
+  end
+end

--- a/lib/dockmaster/parser/ast_parsers/method_parser.rb
+++ b/lib/dockmaster/parser/ast_parsers/method_parser.rb
@@ -1,0 +1,43 @@
+require 'dockmaster/parser/doc_parser'
+
+module Dockmaster
+  # This parser class parses method declarations
+  class MethodParser
+    class << self
+      def parse(line, ast, comments, store, static, priv)
+        return nil unless (ast.type == :defs && ast.to_a[0].type == :self) || ast.type == :def
+        return store if priv && !Dockmaster.include_private?
+        ast_ary = ast.to_a
+        if ast.type == :def
+          name = ast_ary[0]
+          args_ast = ast_ary[1]
+        elsif ast.type == :defs
+          name = ast_ary[1]
+          args_ast = ast_ary[2]
+        end
+        args = []
+
+        unless args_ast.nil?
+          if args_ast.type == :args
+            args_ary = args_ast.to_a
+            args_ary.each do |arg|
+              args << arg.to_a[0] if arg.type == :arg
+            end
+          end
+        end
+
+        static = true if ast.type == :defs
+
+        doc_str = DocParser.closest_comment(line, comments)
+        data_store = if static
+                       store.data_type(:static_method)
+                     else
+                       store.data_type(:instance_method)
+                     end
+        data_store.store(name, Dockmaster::Data.new(doc_str, DocParser.file, ast, line, priv))
+
+        store
+      end
+    end
+  end
+end

--- a/lib/dockmaster/parser/ast_parsers/mod_func_static_parser.rb
+++ b/lib/dockmaster/parser/ast_parsers/mod_func_static_parser.rb
@@ -1,0 +1,15 @@
+require 'dockmaster/parser/doc_parser'
+
+module Dockmaster
+  # This parser class parses module_function statements
+  class ModFuncStaticParser
+    class << self
+      def parse(_line, ast, _comments, store, _static, _priv)
+        return nil unless ast.type == :send
+        return nil unless ast.to_a[1] == :module_function
+        DocParser.make_static
+        store
+      end
+    end
+  end
+end

--- a/lib/dockmaster/parser/ast_parsers/private_parser.rb
+++ b/lib/dockmaster/parser/ast_parsers/private_parser.rb
@@ -1,0 +1,15 @@
+require 'dockmaster/parser/doc_parser'
+
+module Dockmaster
+  # This parser class parses private statements
+  class PrivateParser
+    class << self
+      def parse(_line, ast, _comments, store, _static, _priv)
+        return nil unless ast.type == :send
+        return nil unless ast.to_a[1] == :private
+        DocParser.make_private
+        store
+      end
+    end
+  end
+end

--- a/lib/dockmaster/parser/ast_parsers/sclass_static_parser.rb
+++ b/lib/dockmaster/parser/ast_parsers/sclass_static_parser.rb
@@ -1,0 +1,15 @@
+require 'dockmaster/parser/doc_parser'
+
+module Dockmaster
+  # This parser class parses {@code class &lt;&lt; self} declarations
+  class SClassStaticParser
+    class << self
+      def parse(_line, ast, comments, store, _static, _priv)
+        return nil unless ast.type == :sclass
+        return store if DocParser.valid_first_child(ast, :self).nil?
+        store = DocParser.traverse_ast(ast, comments, store, true, false)
+        store
+      end
+    end
+  end
+end

--- a/lib/dockmaster/parser/data.rb
+++ b/lib/dockmaster/parser/data.rb
@@ -7,12 +7,19 @@ module Dockmaster
     attr_reader :file
     attr_reader :ast
     attr_reader :line
+    attr_reader :private
+    attr_writer :readonly
 
-    def initialize(doc_str, file, ast, line)
+    def initialize(doc_str, file, ast, line, priv)
       @doc_str = doc_str
       @file = file
       @ast = ast
       @line = line
+      @private = priv
+    end
+
+    def readonly?
+      @readonly ||= false
     end
   end
 end

--- a/lib/dockmaster/parser/parser_registry.rb
+++ b/lib/dockmaster/parser/parser_registry.rb
@@ -1,0 +1,33 @@
+module Dockmaster
+  # This class handles the API for abstract syntax tree parsing
+  class ParserRegistry
+    class << self
+      def registered
+        @registry ||= []
+      end
+
+      def register(parser)
+        registered << parser
+      end
+
+      def parse(line, ast, comments, store, static, priv)
+        registered.each do |parser|
+          if parser.respond_to?(:parse)
+            result = parser.parse(line, ast, comments, store, static, priv)
+            return result unless result.nil?
+          end
+        end
+
+        nil
+      end
+
+      def separators
+        @separators = {}
+      end
+
+      def register_separator(type, separator)
+        separators[type] = separator
+      end
+    end
+  end
+end

--- a/spec/dockmaster/docs/processor_defaults_spec.rb
+++ b/spec/dockmaster/docs/processor_defaults_spec.rb
@@ -77,4 +77,13 @@ RSpec.describe Dockmaster::ProcessorDefaults do
       expect(result[:return]).to eq('test')
     end
   end
+
+  context 'with @api annotation' do
+    it 'saves the correct api access level' do
+      src = '# @api private'
+      result = Dockmaster::DocProcessor.process(src, '<none>')
+
+      expect(result[:api]).to eq(:private)
+    end
+  end
 end

--- a/spec/dockmaster/output/output_spec.rb
+++ b/spec/dockmaster/output/output_spec.rb
@@ -17,20 +17,29 @@ RSpec.describe Dockmaster::Output do
       end
     end
 
-    context 'with one module' do
-      it 'creates an \'index.html\' and module files' do
-        store = Dockmaster::DocParser.parse_string('module Test; end', Dockmaster::Store.new(nil, :none, ''))
+    context 'with one module and one class' do
+      it 'creates an \'index.html\' and module/class files' do
+        src = <<-END
+module Test
+  class TestClass
+  end
+end
+        END
+        store = Dockmaster::DocParser.parse_string(src, Dockmaster::Store.new(nil, :none, ''))
 
         store.parse_see_links
         store.parse_docs
 
         Dockmaster::Output.start_processing(store)
 
-        entries = Dir["#{Dockmaster::CONFIG[:output]}/*.html"]
+        entries = Dir["#{Dockmaster::CONFIG[:output]}/**/*.html"]
         entries.delete('.')
         entries.delete('..')
 
-        expect(entries).to eq(["#{Dockmaster::CONFIG[:output]}/index.html", "#{Dockmaster::CONFIG[:output]}/Test.html"])
+        output = Dockmaster::CONFIG[:output]
+        ary = ["#{output}/index.html", "#{output}/Test/TestClass.html", "#{output}/Test.html"]
+
+        expect(entries).to eq(ary)
       end
     end
   end

--- a/spec/dockmaster/output/output_spec.rb
+++ b/spec/dockmaster/output/output_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dockmaster::Output do
         entries.delete('.')
         entries.delete('..')
 
-        expect(entries).to eq(["#{Dockmaster::CONFIG[:output]}/index.html"])
+        expect(entries).to include("#{Dockmaster::CONFIG[:output]}/index.html")
       end
     end
 
@@ -37,9 +37,10 @@ end
         entries.delete('..')
 
         output = Dockmaster::CONFIG[:output]
-        ary = ["#{output}/index.html", "#{output}/Test/TestClass.html", "#{output}/Test.html"]
 
-        expect(entries).to eq(ary)
+        expect(entries).to include("#{output}/index.html")
+        expect(entries).to include("#{output}/Test/TestClass.html")
+        expect(entries).to include("#{output}/Test.html")
       end
     end
   end

--- a/spec/dockmaster/parser/doc_parser_spec.rb
+++ b/spec/dockmaster/parser/doc_parser_spec.rb
@@ -79,32 +79,46 @@ end
   describe '.begin' do
     it 'finds all source files and parses them into a Store with correct documentation' do
       Dir.chdir('spec/files/parser_test') do
+        Dockmaster.include_private
+
         store = Dockmaster::DocParser.begin
 
         expect(store.children.length).to eq(1)
         mod = store.children[0]
         expect(mod.rb_string).to eq('TestFiles')
+        expect(mod.data_type(:static_method)).to have_key(:mod_method)
         expect(mod.children.length).to eq(2)
         class1 = mod.children[0]
         class2 = mod.children[1]
 
         expect(class1.rb_string).to eq('TestFiles::TestFile1')
         expect(class1.docs.description).to eq('Test documentation for TestFile1')
-        expect(class1.field_data).to have_key(:TEST1)
-        expect(class1.field_data[:TEST1].docs.description).to eq('A field (1)')
-        expect(class1.method_data).to have_key(:test_method_1)
-        expect(class1.method_data[:test_method_1].docs.description).to eq('A method (1)')
-        expect(class1.method_data[:test_method_1].docs[:params]).to eq('test' => 'desc(1)')
-        expect(class1.method_data[:test_method_1].docs[:return]).to eq('test(1)')
+        expect(class1.data_type(:constant)).to have_key(:TEST1)
+        expect(class1.data_type(:constant)[:TEST1].docs.description).to eq('A field (1)')
+        expect(class1.data_type(:instance_method)).to have_key(:test_method_1)
+        expect(class1.data_type(:instance_method)[:test_method_1].docs.description).to eq('A method (1)')
+        expect(class1.data_type(:instance_method)[:test_method_1].docs[:params]).to eq('test' => 'desc(1)')
+        expect(class1.data_type(:instance_method)[:test_method_1].docs[:return]).to eq('test(1)')
+        expect(class1.data_type(:static_method)).to have_key(:stest_method_1)
+        expect(class1.data_type(:static_method)[:stest_method_1].docs.description).to eq('A static method (1)')
+        expect(class1.data_type(:static_method)).to have_key(:ptest_method_1)
+        expect(class1.data_type(:static_method)[:ptest_method_1].docs.description).to eq('A private static method (1)')
+        expect(class1.data_type(:static_method)[:ptest_method_1].private).to eq(true)
+        expect(class1.data_type(:instance_field)).to have_key(:test_field)
+        expect(class1.data_type(:instance_field)[:test_field].docs.description).to eq('A non-constant field (1)')
+        expect(class1.data_type(:static_field)).to have_key(:stest_field)
+        expect(class1.data_type(:static_field)[:stest_field].docs.description).to eq('A static non-constant field (1)')
 
         expect(class2.rb_string).to eq('TestFiles::TestFile2')
         expect(class2.docs.description).to eq('Test documentation for TestFile2')
-        expect(class2.field_data).to have_key(:TEST2)
-        expect(class2.field_data[:TEST2].docs.description).to eq('A field (2)')
-        expect(class2.method_data).to have_key(:test_method_2)
-        expect(class2.method_data[:test_method_2].docs.description).to eq('A method (2)')
-        expect(class2.method_data[:test_method_2].docs[:params]).to eq('test' => 'desc(2)')
-        expect(class2.method_data[:test_method_2].docs[:return]).to eq('test(2)')
+        expect(class2.data_type(:constant)).to have_key(:TEST2)
+        expect(class2.data_type(:constant)[:TEST2].docs.description).to eq('A field (2)')
+        expect(class2.data_type(:instance_method)).to have_key(:test_method_2)
+        expect(class2.data_type(:instance_method)[:test_method_2].docs.description).to eq('A method (2)')
+        expect(class2.data_type(:instance_method)[:test_method_2].docs[:params]).to eq('test' => 'desc(2)')
+        expect(class2.data_type(:instance_method)[:test_method_2].docs[:return]).to eq('test(2)')
+        expect(class2.data_type(:static_method)).to have_key(:stest_method_2)
+        expect(class2.data_type(:static_method)[:stest_method_2].docs.description).to eq('A static method (2)')
       end
     end
   end

--- a/spec/dockmaster/parser/store_spec.rb
+++ b/spec/dockmaster/parser/store_spec.rb
@@ -36,11 +36,13 @@ module Test
 
   # More documentation
   class TestClass
+    attr_reader :test_field
+
     def method
     end
 
     # Method with docs
-    def method_w_docs
+    def self.method_w_docs
     end
   end
 end
@@ -52,11 +54,12 @@ end
       exp = <<-END
 (none, , has docs? false)
   (module, Test, has docs? true)
-    (field, TEST, has docs? false)
-    (field, TEST_W_DOCS, has docs? true)
+    (constant, TEST, has docs? false)
+    (constant, TEST_W_DOCS, has docs? true)
     (class, TestClass, has docs? true)
-      (method, method, has docs? false)
-      (method, method_w_docs, has docs? true)
+      (instance_field, test_field, read-only, has docs? false)
+      (instance_method, method, has docs? false)
+      (static_method, method_w_docs, has docs? true)
       END
 
       expect(store.inspect).to eq(exp)

--- a/spec/files/parser_test/testfile_1.rb
+++ b/spec/files/parser_test/testfile_1.rb
@@ -1,4 +1,8 @@
 module TestFiles
+  module_function
+
+  def mod_method; end
+
   # Test documentation for TestFile1
   #
   # @author test(1)
@@ -6,10 +10,26 @@ module TestFiles
     # A field (1)
     TEST1 = 'test'.freeze
 
+    # A non-constant field (1)
+    attr_reader :test_field
+
     # A method (1)
     #
     # @param test desc(1)
     # @return test(1)
     def test_method_1(test); end
+
+    class << self
+      # A static non-constant field (1)
+      attr_reader :stest_field
+
+      # A static method (1)
+      def stest_method_1(test); end
+
+      private
+
+      # A private static method (1)
+      def ptest_method_1(test); end
+    end
   end
 end

--- a/spec/files/parser_test/testfile_2.rb
+++ b/spec/files/parser_test/testfile_2.rb
@@ -11,5 +11,8 @@ module TestFiles
     # @param test desc(2)
     # @return test(2)
     def test_method_2(test); end
+
+    # A static method (2)
+    def self.stest_method_2(_test); end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ RSpec.configure do |config|
 
     Dockmaster.load_externals
 
+    Dockmaster::DocParser.register_default_parsers
     Dockmaster::ProcessorDefaults.register_internals
   end
 


### PR DESCRIPTION
The parser now differentiates between constants, instance fields, static fields, instance methods, and static methods.  On top of this, the private modifier is now parsed, and any private fields or methods are omitted from documentation processing by default.  They can be included using the `-p` or `--include-private` command-line option.

The parser is also modularized in this PR, allowing plugins to add new parsers and parsed types.